### PR TITLE
PE-5913: null error no such method error method not found get render object on null

### DIFF
--- a/lib/src/components/overlay.dart
+++ b/lib/src/components/overlay.dart
@@ -56,29 +56,30 @@ class _ArDriveDropdownState extends State<ArDriveDropdown> {
 
   @override
   void didChangeDependencies() {
-    if (mounted) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        final renderBox = context.findRenderObject() as RenderBox?;
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
 
-        final position = renderBox?.localToGlobal(Offset.zero);
+      final renderBox = context.findRenderObject() as RenderBox?;
 
-        if (position != null && widget.calculateVerticalAlignment != null) {
-          final y = position.dy;
+      final position = renderBox?.localToGlobal(Offset.zero);
 
-          final screenHeight = MediaQuery.of(context).size.height;
+      if (position != null && widget.calculateVerticalAlignment != null) {
+        final y = position.dy;
 
-          Alignment alignment;
+        final screenHeight = MediaQuery.of(context).size.height;
 
-          alignment =
-              widget.calculateVerticalAlignment!.call(y > screenHeight / 2);
+        Alignment alignment;
 
-          _anchor = Aligned(
-            follower: alignment,
-            target: Alignment.bottomLeft,
-          );
-        }
-      });
-    }
+        alignment = widget.calculateVerticalAlignment!(y > screenHeight / 2);
+
+        _anchor = Aligned(
+          follower: alignment,
+          target: Alignment.bottomLeft,
+        );
+      }
+    });
 
     super.didChangeDependencies();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: ardrive_ui
 description: UI Design Library for the ArDrive Design System
 
-version: 1.18.0
+version: 1.18.1
 
 publish_to: "none"
 


### PR DESCRIPTION
 - fixes: NullError: NoSuchMethodError: method not found: 'get$renderObject' on null